### PR TITLE
Remove username from config string when token is present

### DIFF
--- a/fx_data_generator.py
+++ b/fx_data_generator.py
@@ -470,7 +470,7 @@ def ingest_worker(
         auto_flush_interval=10000
 
     if args.protocol == "http":
-        conf = f"http::addr={args.host}:9000;auto_flush_interval={auto_flush_interval};" if not args.token else f"https::addr={args.host}:9000;username={args.ilp_user};token={args.token};tls_verify=unsafe_off;auto_flush_interval={auto_flush_interval};"
+        conf = f"http::addr={args.host}:9000;auto_flush_interval={auto_flush_interval};" if not args.token else f"https::addr={args.host}:9000;token={args.token};tls_verify=unsafe_off;auto_flush_interval={auto_flush_interval};"
     else:
         conf = f"tcp::addr={args.host}:9009;protocol_version=2;auto_flush_interval={auto_flush_interval};" if not args.token else f"tcps::addr={args.host}:9009;username={args.ilp_user};token={args.token};token_x={args.token_x};token_y={args.token_y};tls_verify=unsafe_off;protocol_version=2;auto_flush_interval={auto_flush_interval};"
 


### PR DESCRIPTION
my opts (running enterprise with tls)
```bash
$ docker run --network host  \
sklarsa/fx-data-generator:0.0.7 \
--user qdbadmin \
--password abcdefg123 \
--protocol http \
--token abcdefg123 \
--host localhost
```

the error
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/usr/local/lib/python3.11/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/app/fx_data_generator.py", line 486, in ingest_worker
    with Sender.from_conf(conf) as sender:
  File "src/questdb/ingress.pyx", line 2462, in questdb.ingress.Sender.enter
  File "src/questdb/ingress.pyx", line 2429, in questdb.ingress.Sender.establish
questdb.ingress.IngressError: Inconsistent HTTP authentication parameters. Specify either "username" and "password", or just "token".
```