### PR TITLE
Use TTL for matviews regardless of --enterprise

### DIFF
--- a/fx_data_generator.py
+++ b/fx_data_generator.py
@@ -357,6 +357,16 @@ def retention_clause(short_ttl, enterprise, oss_ttl, enterprise_policy):
     return f'TTL {oss_ttl}'
 
 
+# Materialized views currently cannot accept STORAGE POLICY in QuestDB, so they
+# always fall back to TTL semantics (even in enterprise mode). The enterprise_policy
+# argument is accepted but ignored, so callers can keep their existing signatures
+# and we can revert by pointing the matview `rc` lambda back at retention_clause.
+def mv_retention_clause(short_ttl, enterprise, oss_ttl, enterprise_policy):
+    if not short_ttl:
+        return ''
+    return f'TTL {oss_ttl}'
+
+
 TABLE_ENTERPRISE_POLICY = 'TO parquet 1 hour, DROP NATIVE 2 days, DROP LOCAL 3 months'
 
 
@@ -408,7 +418,10 @@ def ensure_materialized_views_exist(args, suffix):
     conn_str = f"user={args.user} password={args.password} host={args.host} port={args.pg_port} dbname=qdb"
     short_ttl = args.short_ttl
     enterprise = args.enterprise
-    rc = lambda oss_ttl, ep: retention_clause(short_ttl, enterprise, oss_ttl, ep)
+    # Storage policies are not yet supported on materialized views in QuestDB.
+    # To re-enable storage policies for matviews, swap the lambdas below.
+    # rc = lambda oss_ttl, ep: retention_clause(short_ttl, enterprise, oss_ttl, ep)
+    rc = lambda oss_ttl, ep: mv_retention_clause(short_ttl, enterprise, oss_ttl, ep)
     with pg.connect(conn_str, autocommit=True) as conn:
         conn.execute(f"""
         CREATE MATERIALIZED VIEW IF NOT EXISTS {table_name('core_price_1s', suffix)}  AS (


### PR DESCRIPTION
## Summary
- QuestDB does not yet support STORAGE POLICY on materialized views, so matviews always use TTL (in both OSS and enterprise mode).
- Tables continue to use STORAGE POLICY when --enterprise=true and --short_ttl=true.
- New helper mv_retention_clause() mirrors retention_clause() but ignores the enterprise_policy argument. Keeping the matching signature means the 11 matview CREATE statements stay untouched.
- The previous binding is kept as a commented line at the rc lambda so reverting is a one-line swap once matview storage policies land.

## Test plan
- [ ] Run with --short_ttl=true --enterprise=false: matviews get TTL, tables get TTL.
- [ ] Run with --short_ttl=true --enterprise=true: matviews get TTL, tables get STORAGE POLICY.
- [ ] Run with --short_ttl=false: neither tables nor matviews get a retention clause.